### PR TITLE
multi-peak labels

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -34,8 +34,8 @@ pub const PEAK_LABEL_MIN_AMPLITUDE: f64 = 1000.0;
 
 // Constants for spectrum peak labeling
 pub const MAX_PEAKS_TO_LABEL: usize = 4; // Max number of peaks (including primary) to label on spectrum plots
-pub const MIN_SECONDARY_PEAK_FACTOR: f64 = 0.10; // Secondary peak must be at least this factor of primary peak's amplitude
-pub const MIN_PEAK_SEPARATION_HZ: f64 = 50.0; // Minimum frequency separation between reported peaks on spectrum plots
+pub const MIN_SECONDARY_PEAK_FACTOR: f64 = 0.001; // Secondary peak must be at least this factor of primary peak's amplitude
+pub const MIN_PEAK_SEPARATION_HZ: f64 = 30.0; // Minimum frequency separation between reported peaks on spectrum plots
 
 // Constants for individual window step response quality control (from PTstepcalc.m)
 pub const STEADY_STATE_START_S: f64 = 0.2; // Start time for steady-state check within the response window (relative to response start)

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -28,14 +28,14 @@ pub const POST_AVERAGING_SMOOTHING_WINDOW: usize = 5; // Moving average window s
 
 // Constants for the spectrum plot
 pub const SPECTRUM_Y_AXIS_FLOOR: f64 = 20000.0; // Maximum amplitude for spectrum plots.
-pub const SPECTRUM_NOISE_FLOOR_HZ: f64 = 50.0; // Frequency threshold below which to ignore for dynamic Y-axis scaling (e.g., motor idle noise).
+pub const SPECTRUM_NOISE_FLOOR_HZ: f64 = 70.0; // Frequency threshold below which to ignore for dynamic Y-axis scaling (e.g., motor idle noise).
 pub const SPECTRUM_Y_AXIS_HEADROOM_FACTOR: f64 = 1.2; // Factor to extend Y-axis above the highest peak (after noise floor) for better visibility.
 pub const PEAK_LABEL_MIN_AMPLITUDE: f64 = 1000.0;
 
 // Constants for spectrum peak labeling
 pub const MAX_PEAKS_TO_LABEL: usize = 4; // Max number of peaks (including primary) to label on spectrum plots
-pub const MIN_SECONDARY_PEAK_FACTOR: f64 = 0.001; // Secondary peak must be at least this factor of primary peak's amplitude
-pub const MIN_PEAK_SEPARATION_HZ: f64 = 50.0; // Minimum frequency separation between reported peaks on spectrum plots
+pub const MIN_SECONDARY_PEAK_FACTOR: f64 = 0.05; // Secondary peak must be at least this factor of primary peak's amplitude
+pub const MIN_PEAK_SEPARATION_HZ: f64 = 70.0; // Minimum frequency separation between reported peaks on spectrum plots
 // Constants for advanced peak detection
 pub const ENABLE_WINDOW_PEAK_DETECTION: bool = true; // Set to true to use window-based peak detection
                                                      // Set to false to use the previous 3-point (amp > prev && amp >= next) logic.

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -32,6 +32,10 @@ pub const SPECTRUM_NOISE_FLOOR_HZ: f64 = 50.0; // Frequency threshold below whic
 pub const SPECTRUM_Y_AXIS_HEADROOM_FACTOR: f64 = 1.2; // Factor to extend Y-axis above the highest peak (after noise floor) for better visibility.
 pub const PEAK_LABEL_MIN_AMPLITUDE: f64 = 1000.0;
 
+// Constants for spectrum peak labeling
+pub const MAX_PEAKS_TO_LABEL: usize = 4; // Max number of peaks (including primary) to label on spectrum plots
+pub const MIN_SECONDARY_PEAK_FACTOR: f64 = 0.10; // Secondary peak must be at least this factor of primary peak's amplitude
+pub const MIN_PEAK_SEPARATION_HZ: f64 = 50.0; // Minimum frequency separation between reported peaks on spectrum plots
 
 // Constants for individual window step response quality control (from PTstepcalc.m)
 pub const STEADY_STATE_START_S: f64 = 0.2; // Start time for steady-state check within the response window (relative to response start)

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -35,7 +35,11 @@ pub const PEAK_LABEL_MIN_AMPLITUDE: f64 = 1000.0;
 // Constants for spectrum peak labeling
 pub const MAX_PEAKS_TO_LABEL: usize = 4; // Max number of peaks (including primary) to label on spectrum plots
 pub const MIN_SECONDARY_PEAK_FACTOR: f64 = 0.001; // Secondary peak must be at least this factor of primary peak's amplitude
-pub const MIN_PEAK_SEPARATION_HZ: f64 = 30.0; // Minimum frequency separation between reported peaks on spectrum plots
+pub const MIN_PEAK_SEPARATION_HZ: f64 = 50.0; // Minimum frequency separation between reported peaks on spectrum plots
+// Constants for advanced peak detection
+pub const ENABLE_WINDOW_PEAK_DETECTION: bool = true; // Set to true to use window-based peak detection
+                                                     // Set to false to use the previous 3-point (amp > prev && amp >= next) logic.
+pub const PEAK_DETECTION_WINDOW_RADIUS: usize = 3;   // Radius W for peak detection window (total 2*W+1 points).
 
 // Constants for individual window step response quality control (from PTstepcalc.m)
 pub const STEADY_STATE_START_S: f64 = 0.2; // Start time for steady-state check within the response window (relative to response start)

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -33,7 +33,7 @@ pub const SPECTRUM_Y_AXIS_HEADROOM_FACTOR: f64 = 1.2; // Factor to extend Y-axis
 pub const PEAK_LABEL_MIN_AMPLITUDE: f64 = 1000.0;
 
 // Constants for spectrum peak labeling
-pub const MAX_PEAKS_TO_LABEL: usize = 4; // Max number of peaks (including primary) to label on spectrum plots
+pub const MAX_PEAKS_TO_LABEL: usize = 3; // Max number of peaks (including primary) to label on spectrum plots
 pub const MIN_SECONDARY_PEAK_FACTOR: f64 = 0.05; // Secondary peak must be at least this factor of primary peak's amplitude
 pub const MIN_PEAK_SEPARATION_HZ: f64 = 70.0; // Minimum frequency separation between reported peaks on spectrum plots
 // Constants for advanced peak detection

--- a/src/plot_framework.rs
+++ b/src/plot_framework.rs
@@ -68,7 +68,7 @@ pub struct PlotConfig {
     pub series: Vec<PlotSeries>,
     pub x_label: String,
     pub y_label: String,
-    pub peak: Option<(f64, f64)>,
+    pub peaks: Vec<(f64, f64)>, // Changed from Option<(f64, f64)> to Vec<(f64, f64)>
 }
 
 /// Struct to hold spectrum data for a single axis, distinguishing between unfiltered and filtered.
@@ -86,8 +86,8 @@ fn draw_single_axis_chart(
     x_label: &str,
     y_label: &str,
     series: &[PlotSeries],
-    label_prefix: &str,
-    peak_info: Option<(f64, f64)>,
+    label_prefix: &str, // For primary peak label
+    peaks_info: &[(f64, f64)], // Changed from Option<(f64, f64)> to &[(f64, f64)]
 ) -> Result<(), Box<dyn Error>> {
     let mut chart = ChartBuilder::on(area)
         .caption(chart_title, ("sans-serif", 20))
@@ -118,21 +118,34 @@ fn draw_single_axis_chart(
             .background_style(&WHITE.mix(0.8)).border_style(&BLACK).label_font(("sans-serif", 12)).draw()?;
     }
 
-    if let Some((peak_freq, peak_amp)) = peak_info {
+    let plotting_area_offset = chart.plotting_area().get_base_pixel();
+    let (area_x_range, area_y_range) = area.get_pixel_range();
+    let area_width = (area_x_range.end - area_x_range.start) as i32;
+    let area_height = (area_y_range.end - area_y_range.start) as i32;
+    const TEXT_WIDTH_ESTIMATE: i32 = 400; 
+    const TEXT_HEIGHT_ESTIMATE: i32 = 20;
+
+    for (idx, &(peak_freq, peak_amp)) in peaks_info.iter().enumerate() {
         if peak_amp > PEAK_LABEL_MIN_AMPLITUDE {
             let peak_pixel_coords_relative_to_plotting_area = chart.backend_coord(&(peak_freq, peak_amp));
-            let plotting_area_offset = chart.plotting_area().get_base_pixel();
+            
             let mut text_x = peak_pixel_coords_relative_to_plotting_area.0 - plotting_area_offset.0 + 55;
             let mut text_y = peak_pixel_coords_relative_to_plotting_area.1 - plotting_area_offset.1 + 15;
-            let (area_x_range, area_y_range) = area.get_pixel_range();
-            let area_width = (area_x_range.end - area_x_range.start) as i32;
-            let area_height = (area_y_range.end - area_y_range.start) as i32;
-            const TEXT_WIDTH_ESTIMATE: i32 = 400;
-            const TEXT_HEIGHT_ESTIMATE: i32 = 20;
+
+            let label_text;
+
+            if idx == 0 { // Primary peak
+                label_text = format!("{} Peak amplitude {:.0} at {:.0} Hz", label_prefix, peak_amp, peak_freq);
+            } else { // Secondary peaks
+                label_text = format!("Secondary: {:.0} at {:.0} Hz", peak_amp, peak_freq);
+            }
+            
+            // Adjust text position to stay within bounds
             text_x = text_x.max(0).min(area_width - TEXT_WIDTH_ESTIMATE);
             text_y = text_y.max(0).min(area_height - TEXT_HEIGHT_ESTIMATE);
+
             area.draw(&Text::new(
-                format!("{} Peak amplitude {:.0} at {:.0} Hz", label_prefix, peak_amp, peak_freq),
+                label_text,
                 (text_x, text_y),
                 ("sans-serif", 15).into_font().color(&BLACK)
             ))?;
@@ -178,8 +191,8 @@ where
                          &x_label,
                          &y_label,
                          &series_data,
-                         "",
-                         None,
+                         "", // No specific label prefix for generic stacked plots
+                         &[], // Pass empty slice for peaks as this function doesn't handle them yet
                      )?;
                      any_axis_plotted = true;
                  } else {
@@ -259,7 +272,7 @@ where
                         &plot_config.y_label,
                         &plot_config.series,
                         label_prefix_string.as_str(),
-                        plot_config.peak,
+                        &plot_config.peaks, // Pass the Vec of peaks
                     )?;
                     any_plot_drawn = true;
                 } else {

--- a/src/plot_framework.rs
+++ b/src/plot_framework.rs
@@ -86,7 +86,6 @@ fn draw_single_axis_chart(
     x_label: &str,
     y_label: &str,
     series: &[PlotSeries],
-    label_prefix: &str, // For primary peak label
     peaks_info: &[(f64, f64)], // Changed from Option<(f64, f64)> to &[(f64, f64)]
 ) -> Result<(), Box<dyn Error>> {
     let mut chart = ChartBuilder::on(area)
@@ -190,7 +189,6 @@ where
                          &x_label,
                          &y_label,
                          &series_data,
-                         "", // No specific label prefix for generic stacked plots
                          &[], // Pass empty slice for peaks as this function doesn't handle them yet
                      )?;
                      any_axis_plotted = true;
@@ -240,7 +238,6 @@ where
 
     for axis_index in 0..3 {
         let plots_for_axis_option = get_axis_plot_data(axis_index);
-        let current_axis_name = ["Roll", "Pitch", "Yaw"][axis_index];
 
         for col_idx in 0..2 {
             let area = &sub_plot_areas[axis_index * 2 + col_idx];
@@ -257,11 +254,6 @@ where
                 let valid_ranges = plot_config.x_range.end > plot_config.x_range.start && plot_config.y_range.end > plot_config.y_range.start;
 
                 if has_data && valid_ranges {
-                    let label_prefix_string = if col_idx == 0 {
-                        format!("{} Unfiltered", current_axis_name)
-                    } else {
-                        format!("{} Filtered", current_axis_name)
-                    };
                     draw_single_axis_chart(
                         area,
                         &plot_config.title,
@@ -270,7 +262,6 @@ where
                         &plot_config.x_label,
                         &plot_config.y_label,
                         &plot_config.series,
-                        label_prefix_string.as_str(),
                         &plot_config.peaks, // Pass the Vec of peaks
                     )?;
                     any_plot_drawn = true;

--- a/src/plot_framework.rs
+++ b/src/plot_framework.rs
@@ -118,26 +118,25 @@ fn draw_single_axis_chart(
             .background_style(&WHITE.mix(0.8)).border_style(&BLACK).label_font(("sans-serif", 12)).draw()?;
     }
 
-    let plotting_area_offset = chart.plotting_area().get_base_pixel();
+    // Offset of the current sub-area within the root image
+    let area_offset = area.get_base_pixel();
     let (area_x_range, area_y_range) = area.get_pixel_range();
     let area_width = (area_x_range.end - area_x_range.start) as i32;
     let area_height = (area_y_range.end - area_y_range.start) as i32;
-    const TEXT_WIDTH_ESTIMATE: i32 = 400; 
+    const TEXT_WIDTH_ESTIMATE: i32 = 300;
     const TEXT_HEIGHT_ESTIMATE: i32 = 20;
-
     for (idx, &(peak_freq, peak_amp)) in peaks_info.iter().enumerate() {
         if peak_amp > PEAK_LABEL_MIN_AMPLITUDE {
             let peak_pixel_coords_relative_to_plotting_area = chart.backend_coord(&(peak_freq, peak_amp));
-            
-            let mut text_x = peak_pixel_coords_relative_to_plotting_area.0 - plotting_area_offset.0 + 55;
-            let mut text_y = peak_pixel_coords_relative_to_plotting_area.1 - plotting_area_offset.1 + 15;
+            let mut text_x = peak_pixel_coords_relative_to_plotting_area.0 - area_offset.0;
+            let mut text_y = peak_pixel_coords_relative_to_plotting_area.1 - area_offset.1;
 
             let label_text;
 
             if idx == 0 { // Primary peak
-                label_text = format!("{} Peak amplitude {:.0} at {:.0} Hz", label_prefix, peak_amp, peak_freq);
+                label_text = format!("Primary Peak: {:.0} at {:.0} Hz", peak_amp, peak_freq);
             } else { // Secondary peaks
-                label_text = format!("Secondary: {:.0} at {:.0} Hz", peak_amp, peak_freq);
+                label_text = format!("Peak: {:.0} at {:.0} Hz", peak_amp, peak_freq);
             }
             
             // Adjust text position to stay within bounds

--- a/src/plot_functions/plot_gyro_spectrums.rs
+++ b/src/plot_functions/plot_gyro_spectrums.rs
@@ -208,9 +208,9 @@ pub fn plot_gyro_spectrums(
                 peaks_to_plot.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
                 if !peaks_to_plot.is_empty() {
                     let (main_freq, main_amp) = peaks_to_plot[0];
-                    println!("  {} {} Gyro Spectrum: Peak amplitude {:.0} at {:.0} Hz", axis_name_str, spectrum_type_str, main_amp, main_freq);
+                    println!("  {} {} Gyro Spectrum: Primary Peak amplitude {:.0} at {:.0} Hz", axis_name_str, spectrum_type_str, main_amp, main_freq);
                     for (idx, (freq, amp)) in peaks_to_plot.iter().skip(1).enumerate() {
-                        println!("    Secondary Peak {}: {:.0} at {:.0} Hz", idx + 1, amp, freq);
+                        println!("    Subordinate Peak: {}: {:.0} at {:.0} Hz", idx + 1, amp, freq);
                     }
                 } else {
                     println!("  {} {} Gyro Spectrum: No significant peaks found.", axis_name_str, spectrum_type_str);

--- a/src/plot_functions/plot_gyro_spectrums.rs
+++ b/src/plot_functions/plot_gyro_spectrums.rs
@@ -128,7 +128,11 @@ pub fn plot_gyro_spectrums(
                         let prev_amp = series_data[j-1].1;
                         let next_amp = series_data[j+1].1;
 
-                        if freq >= SPECTRUM_NOISE_FLOOR_HZ && amp > prev_amp && amp > next_amp { // Is a local maximum
+                        // A point is a potential candidate if:
+                        // - It's a sharp peak (amp > prev_amp && amp > next_amp)
+                        // - OR it's the leftmost point of a plateau (amp > prev_amp && amp == next_amp)
+                        // This can be combined into: (amp > prev_amp && amp >= next_amp)
+                        if freq >= SPECTRUM_NOISE_FLOOR_HZ && (amp > prev_amp && amp >= next_amp) && amp > PEAK_LABEL_MIN_AMPLITUDE {
                             let mut is_valid_secondary = amp > SPECTRUM_Y_AXIS_FLOOR;
 
                             if let Some((primary_freq, primary_amp)) = primary_peak_info {

--- a/src/plot_functions/plot_gyro_spectrums.rs
+++ b/src/plot_functions/plot_gyro_spectrums.rs
@@ -37,6 +37,119 @@ pub fn plot_gyro_spectrums(
 
     let axis_names = ["Roll", "Pitch", "Yaw"];
 
+    fn find_and_sort_peaks(
+        series_data: &[(f64, f64)],
+        primary_peak_info: Option<(f64, f64)>,
+        axis_name_str: &str, 
+        spectrum_type_str: &str,
+    ) -> Vec<(f64, f64)> {
+        let mut peaks_to_plot: Vec<(f64, f64)> = Vec::new();
+
+        if let Some((peak_freq, peak_amp)) = primary_peak_info {
+            if peak_amp > PEAK_LABEL_MIN_AMPLITUDE {
+                    peaks_to_plot.push((peak_freq, peak_amp));
+            }
+        }
+
+        if series_data.len() > 2 && peaks_to_plot.len() < MAX_PEAKS_TO_LABEL {
+            let mut candidate_secondary_peaks: Vec<(f64, f64)> = Vec::new();
+            // Iterate from the second point to the second-to-last point,
+            // as peak detection logic needs at least one point on each side.
+            for j in 1..(series_data.len() - 1) { 
+                let (freq, amp) = series_data[j];
+                
+                let is_potential_peak = { // Assign directly from the block's result
+                    if ENABLE_WINDOW_PEAK_DETECTION {
+                        let w = PEAK_DETECTION_WINDOW_RADIUS;
+                        // Check if a full window can be formed around j.
+                        // j must be at least w points from the start,
+                        // and j must be at least w points from the end (so j+w is a valid index).
+                        if j >= w && j + w < series_data.len() {
+                            // Full window logic
+                            let mut ge_left_in_window = true;
+                            for k_offset in 1..=w {
+                                // series_data[j - k_offset] is valid because j >= w >= k_offset
+                                if amp < series_data[j - k_offset].1 {
+                                    ge_left_in_window = false;
+                                    break;
+                                }
+                            }
+
+                            let mut gt_right_in_window = true;
+                            if ge_left_in_window { // Optimization: only check right if left is good
+                                for k_offset in 1..=w {
+                                    // series_data[j + k_offset] is valid because j + w < series_data.len()
+                                    // and k_offset <= w
+                                    if amp <= series_data[j + k_offset].1 {
+                                        gt_right_in_window = false;
+                                        break;
+                                    }
+                                }
+                            }
+                            ge_left_in_window && gt_right_in_window // Return this value for this path
+                        } else {
+                            // Fallback for edges where a full window isn't possible.
+                            // The loop for j ensures j-1 and j+1 are always valid.
+                            let prev_amp = series_data[j-1].1;
+                            let next_amp = series_data[j+1].1;
+                            // Using rightmost point of plateau for consistency with window logic's tendency
+                            amp >= prev_amp && amp > next_amp // Return this value for this path
+                        }
+                    } else {
+                        // Original 3-point logic (leftmost point of plateau or sharp peak).
+                        // The loop for j ensures j-1 and j+1 are always valid.
+                        let prev_amp = series_data[j-1].1;
+                        let next_amp = series_data[j+1].1;
+                        amp > prev_amp && amp >= next_amp // Return this value for this path
+                    }
+                }; // End of block assignment to is_potential_peak
+                
+                if freq >= SPECTRUM_NOISE_FLOOR_HZ && is_potential_peak && amp > PEAK_LABEL_MIN_AMPLITUDE {
+                    let mut is_valid_for_secondary_consideration = true;
+                    if let Some((primary_freq, primary_amp_val)) = primary_peak_info {
+                        if freq == primary_freq && amp == primary_amp_val { // Don't re-add the primary peak
+                            is_valid_for_secondary_consideration = false;
+                        } else {
+                            is_valid_for_secondary_consideration = (amp >= primary_amp_val * MIN_SECONDARY_PEAK_FACTOR) &&
+                                                                    ((freq - primary_freq).abs() > MIN_PEAK_SEPARATION_HZ);
+                        }
+                    }
+                    // If no primary_peak_info, is_valid_for_secondary_consideration remains true (as long as it's a potential peak and above min amplitude)
+                    if is_valid_for_secondary_consideration {
+                        candidate_secondary_peaks.push((freq, amp));
+                    }
+                }
+            }
+            
+            candidate_secondary_peaks.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+            for (s_freq, s_amp) in candidate_secondary_peaks {
+                if peaks_to_plot.len() >= MAX_PEAKS_TO_LABEL { break; }
+                let mut too_close_to_existing = false;
+                for (p_freq, _) in &peaks_to_plot {
+                    if (s_freq - *p_freq).abs() < MIN_PEAK_SEPARATION_HZ {
+                        too_close_to_existing = true;
+                        break;
+                    }
+                }
+                if !too_close_to_existing && s_amp > PEAK_LABEL_MIN_AMPLITUDE { // Ensure it's still above min amp
+                    peaks_to_plot.push((s_freq, s_amp));
+                }
+            }
+        }
+        
+        peaks_to_plot.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        if !peaks_to_plot.is_empty() {
+            let (main_freq, main_amp) = peaks_to_plot[0];
+            println!("  {} {} Gyro Spectrum: Primary Peak amplitude {:.0} at {:.0} Hz", axis_name_str, spectrum_type_str, main_amp, main_freq);
+            for (idx, (freq, amp)) in peaks_to_plot.iter().skip(1).enumerate() {
+                println!("    Subordinate Peak: {}: {:.0} at {:.0} Hz", idx + 1, amp, freq);
+            }
+        } else {
+            println!("  {} {} Gyro Spectrum: No significant peaks found.", axis_name_str, spectrum_type_str);
+        }
+        peaks_to_plot
+    }
+
     for axis_idx in 0..3 {
             let axis_name = axis_names[axis_idx];
             let mut unfilt_samples: Vec<f32> = Vec::new();
@@ -105,119 +218,6 @@ pub fn plot_gyro_spectrums(
                 }
             }
 
-            fn find_and_sort_peaks(
-                series_data: &[(f64, f64)],
-                primary_peak_info: Option<(f64, f64)>,
-                axis_name_str: &str, 
-                spectrum_type_str: &str,
-            ) -> Vec<(f64, f64)> {
-                let mut peaks_to_plot: Vec<(f64, f64)> = Vec::new();
-
-                if let Some((peak_freq, peak_amp)) = primary_peak_info {
-                    if peak_amp > PEAK_LABEL_MIN_AMPLITUDE {
-                         peaks_to_plot.push((peak_freq, peak_amp));
-                    }
-                }
-
-                if series_data.len() > 2 && peaks_to_plot.len() < MAX_PEAKS_TO_LABEL {
-                    let mut candidate_secondary_peaks: Vec<(f64, f64)> = Vec::new();
-                    // Iterate from the second point to the second-to-last point,
-                    // as peak detection logic needs at least one point on each side.
-                    for j in 1..(series_data.len() - 1) { 
-                        let (freq, amp) = series_data[j];
-                        
-                        let is_potential_peak = { // Assign directly from the block's result
-                            if ENABLE_WINDOW_PEAK_DETECTION {
-                                let w = PEAK_DETECTION_WINDOW_RADIUS;
-                                // Check if a full window can be formed around j.
-                                // j must be at least w points from the start,
-                                // and j must be at least w points from the end (so j+w is a valid index).
-                                if j >= w && j + w < series_data.len() {
-                                    // Full window logic
-                                    let mut ge_left_in_window = true;
-                                    for k_offset in 1..=w {
-                                        // series_data[j - k_offset] is valid because j >= w >= k_offset
-                                        if amp < series_data[j - k_offset].1 {
-                                            ge_left_in_window = false;
-                                            break;
-                                        }
-                                    }
-
-                                    let mut gt_right_in_window = true;
-                                    if ge_left_in_window { // Optimization: only check right if left is good
-                                        for k_offset in 1..=w {
-                                            // series_data[j + k_offset] is valid because j + w < series_data.len()
-                                            // and k_offset <= w
-                                            if amp <= series_data[j + k_offset].1 {
-                                                gt_right_in_window = false;
-                                                break;
-                                            }
-                                        }
-                                    }
-                                    ge_left_in_window && gt_right_in_window // Return this value for this path
-                                } else {
-                                    // Fallback for edges where a full window isn't possible.
-                                    // The loop for j ensures j-1 and j+1 are always valid.
-                                    let prev_amp = series_data[j-1].1;
-                                    let next_amp = series_data[j+1].1;
-                                    // Using rightmost point of plateau for consistency with window logic's tendency
-                                    amp >= prev_amp && amp > next_amp // Return this value for this path
-                                }
-                            } else {
-                                // Original 3-point logic (leftmost point of plateau or sharp peak).
-                                // The loop for j ensures j-1 and j+1 are always valid.
-                                let prev_amp = series_data[j-1].1;
-                                let next_amp = series_data[j+1].1;
-                                amp > prev_amp && amp >= next_amp // Return this value for this path
-                            }
-                        }; // End of block assignment to is_potential_peak
-                        
-                        if freq >= SPECTRUM_NOISE_FLOOR_HZ && is_potential_peak && amp > PEAK_LABEL_MIN_AMPLITUDE {
-                            let mut is_valid_for_secondary_consideration = true;
-                            if let Some((primary_freq, primary_amp_val)) = primary_peak_info {
-                                if freq == primary_freq && amp == primary_amp_val { // Don't re-add the primary peak
-                                    is_valid_for_secondary_consideration = false;
-                                } else {
-                                    is_valid_for_secondary_consideration = (amp >= primary_amp_val * MIN_SECONDARY_PEAK_FACTOR) &&
-                                                                          ((freq - primary_freq).abs() > MIN_PEAK_SEPARATION_HZ);
-                                }
-                            }
-                            // If no primary_peak_info, is_valid_for_secondary_consideration remains true (as long as it's a potential peak and above min amplitude)
-                            if is_valid_for_secondary_consideration {
-                                candidate_secondary_peaks.push((freq, amp));
-                            }
-                        }
-                    }
-                    
-                    candidate_secondary_peaks.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
-                    for (s_freq, s_amp) in candidate_secondary_peaks {
-                        if peaks_to_plot.len() >= MAX_PEAKS_TO_LABEL { break; }
-                        let mut too_close_to_existing = false;
-                        for (p_freq, _) in &peaks_to_plot {
-                            if (s_freq - *p_freq).abs() < MIN_PEAK_SEPARATION_HZ {
-                                too_close_to_existing = true;
-                                break;
-                            }
-                        }
-                        if !too_close_to_existing && s_amp > PEAK_LABEL_MIN_AMPLITUDE { // Ensure it's still above min amp
-                            peaks_to_plot.push((s_freq, s_amp));
-                        }
-                    }
-                }
-                
-                peaks_to_plot.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
-                if !peaks_to_plot.is_empty() {
-                    let (main_freq, main_amp) = peaks_to_plot[0];
-                    println!("  {} {} Gyro Spectrum: Primary Peak amplitude {:.0} at {:.0} Hz", axis_name_str, spectrum_type_str, main_amp, main_freq);
-                    for (idx, (freq, amp)) in peaks_to_plot.iter().skip(1).enumerate() {
-                        println!("    Subordinate Peak: {}: {:.0} at {:.0} Hz", idx + 1, amp, freq);
-                    }
-                } else {
-                    println!("  {} {} Gyro Spectrum: No significant peaks found.", axis_name_str, spectrum_type_str);
-                }
-                peaks_to_plot
-            }
-
             let unfilt_peaks_for_plot = find_and_sort_peaks(&unfilt_series_data, primary_peak_unfilt, axis_name, "Unfiltered");
             let filt_peaks_for_plot = find_and_sort_peaks(&filt_series_data, primary_peak_filt, axis_name, "Filtered");
 
@@ -236,8 +236,8 @@ pub fn plot_gyro_spectrums(
     }
 
     overall_max_y_amplitude = overall_max_y_amplitude.max(global_max_y_unfilt).max(global_max_y_filt);
-    if overall_max_y_amplitude < SPECTRUM_Y_AXIS_FLOOR * 1.1 { 
-        overall_max_y_amplitude = SPECTRUM_Y_AXIS_FLOOR * 1.1;
+    if overall_max_y_amplitude < SPECTRUM_Y_AXIS_FLOOR { 
+        overall_max_y_amplitude = SPECTRUM_Y_AXIS_FLOOR;
     }
 
     draw_dual_spectrum_plot(

--- a/src/plot_functions/plot_gyro_spectrums.rs
+++ b/src/plot_functions/plot_gyro_spectrums.rs
@@ -121,62 +121,68 @@ pub fn plot_gyro_spectrums(
 
                 if series_data.len() > 2 && peaks_to_plot.len() < MAX_PEAKS_TO_LABEL {
                     let mut candidate_secondary_peaks: Vec<(f64, f64)> = Vec::new();
-                    for j in 1..(series_data.len() - 1) { // Iterate from second to second-to-last point
+                    // Iterate from the second point to the second-to-last point,
+                    // as peak detection logic needs at least one point on each side.
+                    for j in 1..(series_data.len() - 1) { 
                         let (freq, amp) = series_data[j];
                         
-                        let mut is_potential_peak = false;
-
-                        if ENABLE_WINDOW_PEAK_DETECTION {
-                            let w = PEAK_DETECTION_WINDOW_RADIUS;
-                            // Check if a full window can be formed around j
-                            if j >= w && j + w < series_data.len() {
-                                // Full window logic
-                                let mut ge_left_in_window = true;
-                                for k_offset in 1..=w {
-                                    // j >= k_offset is true because j >= w
-                                    if amp < series_data[j - k_offset].1 {
-                                        ge_left_in_window = false;
-                                        break;
-                                    }
-                                }
-
-                                let mut gt_right_in_window = true;
-                                if ge_left_in_window {
+                        let is_potential_peak = { // Assign directly from the block's result
+                            if ENABLE_WINDOW_PEAK_DETECTION {
+                                let w = PEAK_DETECTION_WINDOW_RADIUS;
+                                // Check if a full window can be formed around j.
+                                // j must be at least w points from the start,
+                                // and j must be at least w points from the end (so j+w is a valid index).
+                                if j >= w && j + w < series_data.len() {
+                                    // Full window logic
+                                    let mut ge_left_in_window = true;
                                     for k_offset in 1..=w {
-                                        // j + k_offset < series_data.len() is true because j + w < series_data.len()
-                                        if amp <= series_data[j + k_offset].1 {
-                                            gt_right_in_window = false;
+                                        // series_data[j - k_offset] is valid because j >= w >= k_offset
+                                        if amp < series_data[j - k_offset].1 {
+                                            ge_left_in_window = false;
                                             break;
                                         }
                                     }
+
+                                    let mut gt_right_in_window = true;
+                                    if ge_left_in_window { // Optimization: only check right if left is good
+                                        for k_offset in 1..=w {
+                                            // series_data[j + k_offset] is valid because j + w < series_data.len()
+                                            // and k_offset <= w
+                                            if amp <= series_data[j + k_offset].1 {
+                                                gt_right_in_window = false;
+                                                break;
+                                            }
+                                        }
+                                    }
+                                    ge_left_in_window && gt_right_in_window // Return this value for this path
+                                } else {
+                                    // Fallback for edges where a full window isn't possible.
+                                    // The loop for j ensures j-1 and j+1 are always valid.
+                                    let prev_amp = series_data[j-1].1;
+                                    let next_amp = series_data[j+1].1;
+                                    // Using rightmost point of plateau for consistency with window logic's tendency
+                                    amp >= prev_amp && amp > next_amp // Return this value for this path
                                 }
-                                is_potential_peak = ge_left_in_window && gt_right_in_window;
                             } else {
-                                // Fallback for edges where a full window isn't possible
-                                // Use a 3-point check (rightmost point of plateau or sharp peak)
-                                // This requires j > 0 and j < series_data.len() - 1, which is guaranteed by the loop bounds
+                                // Original 3-point logic (leftmost point of plateau or sharp peak).
+                                // The loop for j ensures j-1 and j+1 are always valid.
                                 let prev_amp = series_data[j-1].1;
                                 let next_amp = series_data[j+1].1;
-                                is_potential_peak = amp >= prev_amp && amp > next_amp;
+                                amp > prev_amp && amp >= next_amp // Return this value for this path
                             }
-                        } else {
-                            // Original 3-point logic (leftmost point of plateau or sharp peak)
-                            // This requires j > 0 and j < series_data.len() - 1, which is guaranteed by the loop bounds
-                            let prev_amp = series_data[j-1].1;
-                            let next_amp = series_data[j+1].1;
-                            is_potential_peak = amp > prev_amp && amp >= next_amp;
-                        }
+                        }; // End of block assignment to is_potential_peak
                         
                         if freq >= SPECTRUM_NOISE_FLOOR_HZ && is_potential_peak && amp > PEAK_LABEL_MIN_AMPLITUDE {
                             let mut is_valid_for_secondary_consideration = true;
                             if let Some((primary_freq, primary_amp_val)) = primary_peak_info {
-                                if freq == primary_freq && amp == primary_amp_val {
+                                if freq == primary_freq && amp == primary_amp_val { // Don't re-add the primary peak
                                     is_valid_for_secondary_consideration = false;
                                 } else {
                                     is_valid_for_secondary_consideration = (amp >= primary_amp_val * MIN_SECONDARY_PEAK_FACTOR) &&
                                                                           ((freq - primary_freq).abs() > MIN_PEAK_SEPARATION_HZ);
                                 }
                             }
+                            // If no primary_peak_info, is_valid_for_secondary_consideration remains true (as long as it's a potential peak and above min amplitude)
                             if is_valid_for_secondary_consideration {
                                 candidate_secondary_peaks.push((freq, amp));
                             }
@@ -193,7 +199,7 @@ pub fn plot_gyro_spectrums(
                                 break;
                             }
                         }
-                        if !too_close_to_existing && s_amp > PEAK_LABEL_MIN_AMPLITUDE {
+                        if !too_close_to_existing && s_amp > PEAK_LABEL_MIN_AMPLITUDE { // Ensure it's still above min amp
                             peaks_to_plot.push((s_freq, s_amp));
                         }
                     }


### PR DESCRIPTION
- **multi-amplitude peak labels**
- **multi-amplitude peak tuning**
- **multi-amplitude peak tuning; mult-peak working better, but existing warning to be fixed**
- **multi-amplitude peak tuning; mult-peak working; with more tuning**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Spectrum plots now display and label multiple significant peaks per axis, rather than just a single peak.
  - Improved detection and labeling of secondary peaks with configurable parameters for amplitude threshold, frequency separation, and number of peaks.
  - Enhanced peak label positioning for better readability.

- **Bug Fixes**
  - More robust handling of peak detection near plot boundaries and improved y-axis scaling for spectrum plots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->