### PR TITLE
rename project and setup github actions artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,16 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        include:
+          - os: ubuntu-latest
+            artifact_name: binary-linux
+            binary_path: target/release/BlackBox_CSV_Render
+          - os: windows-latest
+            artifact_name: binary-windows
+            binary_path: target/release/BlackBox_CSV_Render.exe
+          - os: macos-latest
+            artifact_name: binary-macos
+            binary_path: target/release/BlackBox_CSV_Render
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -25,3 +34,11 @@ jobs:
       - name: Set CARGO_PROFILE_RELEASE_BUILD_OVERRIDE_DEBUG
         run: echo "CARGO_PROFILE_RELEASE_BUILD_OVERRIDE_DEBUG=true" >> $GITHUB_ENV
       - run: cargo build --release
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact_name }}
+          path: ${{ matrix.binary_path }}
+          overwrite: true
+          if-no-files-found: error
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,7 +3,7 @@
 version = 4
 
 [[package]]
-name = "RUST_BlackBox_CSV_Render"
+name = "BlackBox_CSV_Render"
 version = "0.1.0"
 dependencies = [
  "colorous",
@@ -74,9 +74,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
-version = "1.2.24"
+version = "1.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16595d3be041c03b09d08d0858631facccee9221e579704070e6e9e4915d3bc7"
+checksum = "d0fc897dc1e865cc67c0e05a836d9d3f1df3cbe442aa4a9473b18e12624a4951"
 dependencies = [
  "shlex",
 ]
@@ -451,9 +451,9 @@ checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libloading"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a793df0d7afeac54f95b471d3af7f0d4fb975699f972341a4b76988d49cdf0c"
+checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
  "windows-targets 0.53.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "RUST_BlackBox_CSV_Render"
+name = "BlackBox_CSV_Render"
 version = "0.1.0"
 edition = "2021" # Use 2021 edition as it's standard, 2024 is not yet released/stable
 

--- a/Readme.md
+++ b/Readme.md
@@ -5,13 +5,28 @@
 1. https://www.rust-lang.org/tools/install
 2. [blackbox_decode](https://github.com/betaflight/blackbox-tools) your BBL to CSV (`--save-headers`, `--index <num>`, and `--limits` parameters may be useful)
 
-### Build and execute
+### Build
 
 ```shell
 cargo build --release
-./target/release/RUST_BlackBox_CSV_Render path/to/BTFL_Log.csv
-ls *.png
 ```
+
+### Example execution commands
+```shell
+./target/release/BlackBox_CSV_Render path/to/BTFL_Log.csv
+```
+```shell
+./target/release/BlackBox_CSV_Render path/to/BTFL_Log.csv [--dps [<value>]]
+```
+```shell
+./target/release/BlackBox_CSV_Render path/to/*.csv --dps
+```
+```shell
+./target/release/BlackBox_CSV_Render path1/to/BTFL_Log.csv path2/to/*.csv --dps 360
+```
+
+### Output
+- PNG files are generated in the current directory.
 
 ### Licensing still under consideration.
 - Some resources used for the AI prompting included the following, but only for inspiration.


### PR DESCRIPTION
- renaming  project to just `Blackbox_CSV_Render` (removed `RUST_`)
- upload build artifacts (available via GitHub Actions Runs)
- updated Readme.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the package name to "BlackBox_CSV_Render".
  - Enhanced the build workflow to upload the compiled binary artifact after the release build.
  - Improved documentation with clearer build instructions, example execution commands, and output details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->